### PR TITLE
Broaden reg-ex to all resolver variants

### DIFF
--- a/cli-index.js
+++ b/cli-index.js
@@ -20,7 +20,7 @@ if (argv.h) {
   'Options: \n' +
   '-e, --exact  Find an exact match \n' +
   '-d, --declared   Find a DOI with a `doi:` prefix\n' +
-  '-r, --resolvePath  Find a DOI with a `https://dx.doi.org` prefix\n' +
+  '-r, --resolvePath  Find a DOI with a `https://doi.org` or `https://dx.doi.org` prefix\n' +
   '-m, --match  Find all matches within the given string\n' +
   '-g, --groups  Find matches with groupings for extra suffixes')
   process.exit(-1)

--- a/coverage/lcov-report/doi-regex/index.js.html
+++ b/coverage/lcov-report/doi-regex/index.js.html
@@ -197,8 +197,8 @@ doi.declared = function (opts) {
 &nbsp;
 doi.resolvePath = function (opts) {
   opts = opts || {}
-  return opts.protocol ? new RegExp('^http(s)?\\://dx\\.doi\\.org/' + doiRegex + '$') :
-    new RegExp('^(http(s)?\\://)?dx\\.doi\\.org/' + doiRegex + '$')
+  return opts.protocol ? new RegExp('^http(s)?\\://(dx\\.)?doi\\.org/' + doiRegex + '$') :
+    new RegExp('^(http(s)?\\://)?(dx\\.)?doi\\.org/' + doiRegex + '$')
 }
 &nbsp;</pre></td></tr>
 </table></pre>

--- a/index.js
+++ b/index.js
@@ -50,6 +50,6 @@ doi.declared = function (opts) {
 
 doi.resolvePath = function (opts) {
   opts = opts || {}
-  return opts.protocol ? new RegExp('^http(s)?\\://dx\\.doi\\.org/' + doiRegex + '$') :
-    new RegExp('^(http(s)?\\://)?dx\\.doi\\.org/' + doiRegex + '$')
+  return opts.protocol ? new RegExp('^http(s)?\\://(dx\\.)?doi\\.org/' + doiRegex + '$') :
+    new RegExp('^(http(s)?\\://)?(dx\\.)?doi\\.org/' + doiRegex + '$')
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -24,11 +24,14 @@ var doiDeclared = [
 
 var doiResolvePathWithoutProtocol = [
   'dx.doi.org/10.1016/j.neuron.2014.09.004'
+  'doi.org/10.1016/j.neuron.2014.09.004'
 ]
 
 var doiResolvePathWithProtocol = [
   'http://dx.doi.org/10.1016/j.neuron.2014.09.004',
-  'https://dx.doi.org/10.1016/j.neuron.2014.09.004'
+  'https://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'http://doi.org/10.1016/j.neuron.2014.09.004',
+  'https://doi.org/10.1016/j.neuron.2014.09.004'
 ]
 
 var doiResolvePathInvalid = [
@@ -37,7 +40,9 @@ var doiResolvePathInvalid = [
 
 var doiResolvePathWithProtocolInvalid = [
   'httpp://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'httpp://doi.org/10.1016/j.neuron.2014.09.004',
   'ftp://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'ftp://doi.org/10.1016/j.neuron.2014.09.004',
 ]
 
 var doiNotDeclared = [


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the docu, reg-exes and tests.

Cheers!