### PR TITLE
Broaden reg-ex to all resolver variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,6 @@ doi.declared = function (opts) {
 
 doi.resolvePath = function (opts) {
   opts = opts || {}
-  return opts.protocol ? new RegExp('^http(s)?\\://dx\\.doi\\.org/' + doiRegex + '$') :
-    new RegExp('^(http(s)?\\://)?dx\\.doi\\.org/' + doiRegex + '$')
+  return opts.protocol ? new RegExp('^http(s)?\\://(dx\\.)?doi\\.org/' + doiRegex + '$') :
+    new RegExp('^(http(s)?\\://)?(dx\\.)?doi\\.org/' + doiRegex + '$')
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -23,12 +23,15 @@ var doiDeclared = [
 ]
 
 var doiResolvePathWithoutProtocol = [
-  'dx.doi.org/10.1016/j.neuron.2014.09.004'
+  'dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'doi.org/10.1016/j.neuron.2014.09.004'
 ]
 
 var doiResolvePathWithProtocol = [
   'http://dx.doi.org/10.1016/j.neuron.2014.09.004',
-  'https://dx.doi.org/10.1016/j.neuron.2014.09.004'
+  'https://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'http://doi.org/10.1016/j.neuron.2014.09.004',
+  'https://doi.org/10.1016/j.neuron.2014.09.004'
 ]
 
 var doiResolvePathInvalid = [
@@ -37,7 +40,9 @@ var doiResolvePathInvalid = [
 
 var doiResolvePathWithProtocolInvalid = [
   'httpp://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'httpp://doi.org/10.1016/j.neuron.2014.09.004',
   'ftp://dx.doi.org/10.1016/j.neuron.2014.09.004',
+  'ftp://doi.org/10.1016/j.neuron.2014.09.004',
 ]
 
 var doiNotDeclared = [


### PR DESCRIPTION
Same as #7, but with [a fix for the broken test](https://github.com/regexhq/doi-regex/pull/7/files#r202541726).