### PR TITLE
Allow 2 digit registrant codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 /**
  * Parts of a DOI:
  * Directory Identifier: 10
- * Registrant code: . + [0-9]{4,}
+ * Registrant code: . + [0-9]{2,}
  * Registrant subdivision (optional): . + [0-9]+
  * Suffix: / + any character, case insensitive for ASCII chars (but capitalised
  *   in the registry), with some characters that _should_ be escaped.
@@ -14,7 +14,7 @@
 
 // TODO Capture final segment for fragments
 // (\\.[a-zA-Z]{1}[0-9]{3})?
-var doiRegex = '(10[.][0-9]{4,}(?:[.][0-9]+)*/(?:(?![%"#? ])\\S)+)'
+var doiRegex = '(10[.][0-9]{2,}(?:[.][0-9]+)*/(?:(?![%"#? ])\\S)+)'
 var doiTextPrefix = 'doi\\:'
 
 var doi = module.exports = function (opts) {

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 Parts of a DOI:
  * Directory Identifier: 10
- * Registrant code: . + [0-9]{4,}
+ * Registrant code: . + [0-9]{2,}
  * Registrant subdivision (optional): . + [0-9]+
  * Suffix: / + any character, case insensitive for ASCII chars (but capitalised
 	in the registry), with some characters that _should_ be escaped  

--- a/spec/test.js
+++ b/spec/test.js
@@ -8,7 +8,8 @@ var doi = [
   '10.0001/journal.pone.000001',
   '10.0001/journal/pone.0011111',
   '10.0001.112/journal.pone.0011021',
-  '10.0001/issn.10001'
+  '10.0001/issn.10001',
+  '10.10.123/456'
 ]
 
 var doiOlderFormat = [


### PR DESCRIPTION
Registrant codes can be 2-digits long (e.g. https://doi.org/10.10).

I've used an example from doi.org (https://www.doi.org/factsheets/DOIProxy.html); an example of a real DOI is https://doi.org/10.21/2V9FYC24.